### PR TITLE
Adding IJ2 Ops: Benchmarks for ImgLib2 Ops and CLIJ Ops

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,11 @@ THE POSSIBILITY OF SUCH DAMAGE.
             <artifactId>mpicbg</artifactId>
             <version>1.2.0</version>
         </dependency>
+        <dependency>
+            <groupId>net.haesleinhuepf</groupId>
+            <artifactId>clij-ops</artifactId>
+            <version>1.0.7</version>
+        </dependency>
     </dependencies>
 
 
@@ -153,6 +158,9 @@ THE POSSIBILITY OF SUCH DAMAGE.
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/json/org.scijava.plugin.Plugin</resource>
                                 </transformer>
                             </transformers>
                             <filters>

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/imagecomparison/ImageComparison.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/imagecomparison/ImageComparison.java
@@ -146,7 +146,7 @@ public class ImageComparison {
                         } else if (result instanceof ClearCLBuffer) {
                             impResult = CLIJ.getInstance().pull((ClearCLBuffer) result);
                         }else if (result instanceof RandomAccessibleInterval) {
-	                        impResult = ImageJFunctions.wrap((RandomAccessibleInterval)result, "result");
+	                        impResult = new Duplicator().run(ImageJFunctions.wrap((RandomAccessibleInterval)result, "result"));
                         }
                         if (impResult != null) {
                             if (impResult.getNSlices() > 1) {

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/imagecomparison/ImageComparison.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/imagecomparison/ImageComparison.java
@@ -20,6 +20,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Comparator;
 
 
 public class ImageComparison {
@@ -101,7 +103,9 @@ public class ImageComparison {
             StringBuilder statsline = new StringBuilder();
             statsline.append("<tr><td>&nbsp;</td>");
 
-            for (Method method : benchmark.getClass().getMethods()) {
+            Method[] methods = Arrays.copyOf(benchmark.getClass().getMethods(), benchmark.getClass().getMethods().length);
+            Arrays.sort(methods, Comparator.comparing(Method::getName));
+            for (Method method : methods) {
                 String methodname = method.getName();
                 System.out.println(methodname);
                 if (

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/AddImagesWeighted2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/AddImagesWeighted2D.java
@@ -1,8 +1,10 @@
 package net.haesleinhuepf.clij.benchmark.jmh;
 
-import ij.ImagePlus;
 import ij.plugin.ImageCalculator;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_addImagesWeighted.CLIJ_addImagesWeighted;
+import net.imglib2.IterableInterval;
+import net.imglib2.img.Img;
 import org.openjdk.jmh.annotations.Benchmark;
 
 public class AddImagesWeighted2D extends AbstractBenchmark {
@@ -19,6 +21,25 @@ public class AddImagesWeighted2D extends AbstractBenchmark {
         ClearCLBuffer clb2Dc = images.getCLImage2Dc();
 
         images.clij.op().addImagesWeighted(clb2Da, clb2Db, clb2Dc, 1f, 1f);
+        return clb2Dc;
+    }
+
+    @Benchmark
+    public Object ijOps(ImgLib2Images images) {
+        Img img2Da = images.getImg2Da();
+        Img img2Db = images.getImg2Db();
+        Img img2Dc = images.getImg2Dc();
+        images.getOpService().math().add(img2Dc, img2Da, (IterableInterval)img2Db);
+        return img2Dc;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images) {
+        ClearCLBuffer clb2Da = images.getCLImage2Da();
+        ClearCLBuffer clb2Db = images.getCLImage2Db();
+        ClearCLBuffer clb2Dc = images.getCLImage2Dc();
+
+        images.getOpService().run(CLIJ_addImagesWeighted.class, clb2Dc, clb2Da, clb2Db, 1f, 1f);
         return clb2Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/AddImagesWeighted3D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/AddImagesWeighted3D.java
@@ -2,6 +2,9 @@ package net.haesleinhuepf.clij.benchmark.jmh;
 
 import ij.plugin.ImageCalculator;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_addImagesWeighted.CLIJ_addImagesWeighted;
+import net.imglib2.IterableInterval;
+import net.imglib2.img.Img;
 import org.openjdk.jmh.annotations.Benchmark;
 
 public class AddImagesWeighted3D extends AbstractBenchmark {
@@ -18,6 +21,25 @@ public class AddImagesWeighted3D extends AbstractBenchmark {
         ClearCLBuffer clb3Dc = images.getCLImage3Dc();
 
         images.clij.op().addImagesWeighted(clb3Da, clb3Db, clb3Dc, 1f, 1f);
+        return clb3Dc;
+    }
+
+    @Benchmark
+    public Object ijOps(ImgLib2Images images) {
+        Img img3Da = images.getImg3Da();
+        Img img3Db = images.getImg3Db();
+        Img img3Dc = images.getImg3Dc();
+        images.getOpService().math().add(img3Dc, img3Da, (IterableInterval)img3Db);
+        return img3Dc;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images) {
+        ClearCLBuffer clb3Da = images.getCLImage3Da();
+        ClearCLBuffer clb3Db = images.getCLImage3Db();
+        ClearCLBuffer clb3Dc = images.getCLImage3Dc();
+
+        images.getOpService().run(CLIJ_addImagesWeighted.class, clb3Dc, clb3Da, clb3Db, 1f, 1f);
         return clb3Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/AddScalar2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/AddScalar2D.java
@@ -2,8 +2,12 @@ package net.haesleinhuepf.clij.benchmark.jmh;
 
 import ij.IJ;
 import ij.ImagePlus;
-import ij.plugin.ImageCalculator;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_addImageAndScalar.CLIJ_addImageAndScalar;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.Views;
 import org.openjdk.jmh.annotations.Benchmark;
 
 public class AddScalar2D extends AbstractBenchmark {
@@ -27,5 +31,24 @@ public class AddScalar2D extends AbstractBenchmark {
         ImagePlus imp2D = images.getImp2Da();
         IJ.run(imp2D, "Add...", "value=1");
         return imp2D;
+    }
+
+    @Benchmark
+    public <T extends RealType> Object ijOps(ImgLib2Images images) {
+        RandomAccessibleInterval<T> img2Da = images.getImg2Da();
+        RandomAccessibleInterval<T> img2Dc = images.getImg2Dc();
+        T val = ((Img<T>) img2Da).firstElement();
+        val.setReal(1);
+        images.getOpService().math().add(Views.iterable(img2Dc), Views.iterable(img2Da), val);
+        return img2Dc;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images) {
+        ClearCLBuffer clb2Da = images.getCLImage2Da();
+        ClearCLBuffer clb2Dc = images.getCLImage2Dc();
+
+        images.getOpService().run(CLIJ_addImageAndScalar.class, clb2Dc, clb2Da, 1f);
+        return clb2Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/AddScalar2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/AddScalar2D.java
@@ -37,7 +37,7 @@ public class AddScalar2D extends AbstractBenchmark {
     public <T extends RealType> Object ijOps(ImgLib2Images images) {
         RandomAccessibleInterval<T> img2Da = images.getImg2Da();
         RandomAccessibleInterval<T> img2Dc = images.getImg2Dc();
-        T val = ((Img<T>) img2Da).firstElement();
+        T val = (T) ((Img<T>) img2Da).firstElement().copy();
         val.setReal(1);
         images.getOpService().math().add(Views.iterable(img2Dc), Views.iterable(img2Da), val);
         return img2Dc;

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/AddScalar3D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/AddScalar3D.java
@@ -3,6 +3,11 @@ package net.haesleinhuepf.clij.benchmark.jmh;
 import ij.IJ;
 import ij.ImagePlus;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_addImageAndScalar.CLIJ_addImageAndScalar;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.Views;
 import org.openjdk.jmh.annotations.Benchmark;
 
 public class AddScalar3D extends AbstractBenchmark {
@@ -30,5 +35,24 @@ public class AddScalar3D extends AbstractBenchmark {
         ImagePlus imp3D = images.getImp3Da();
         IJ.run(imp3D, "Add...", "value=1 stack");
         return imp3D;
+    }
+
+    @Benchmark
+    public <T extends RealType> Object ijOps(ImgLib2Images images) {
+        RandomAccessibleInterval<T> img3Da = images.getImg3Da();
+        RandomAccessibleInterval<T> img3Dc = images.getImg3Dc();
+        T val = ((Img<T>) img3Da).firstElement();
+        val.setReal(1);
+        images.getOpService().math().add(Views.iterable(img3Dc), Views.iterable(img3Da), val);
+        return img3Dc;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images) {
+        ClearCLBuffer clb3Da = images.getCLImage3Da();
+        ClearCLBuffer clb3Dc = images.getCLImage3Dc();
+
+        images.getOpService().run(CLIJ_addImageAndScalar.class, clb3Dc, clb3Da, 1f);
+        return clb3Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/AddScalar3D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/AddScalar3D.java
@@ -41,7 +41,7 @@ public class AddScalar3D extends AbstractBenchmark {
     public <T extends RealType> Object ijOps(ImgLib2Images images) {
         RandomAccessibleInterval<T> img3Da = images.getImg3Da();
         RandomAccessibleInterval<T> img3Dc = images.getImg3Dc();
-        T val = ((Img<T>) img3Da).firstElement();
+        T val = (T) ((Img<T>) img3Da).firstElement().copy();
         val.setReal(1);
         images.getOpService().math().add(Views.iterable(img3Dc), Views.iterable(img3Da), val);
         return img3Dc;

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/AutoThreshold2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/AutoThreshold2D.java
@@ -5,11 +5,10 @@ import ij.ImagePlus;
 import ij.plugin.Thresholder;
 import ij.process.AutoThresholder;
 import ij.process.ByteProcessor;
-import ij.process.ImageStatistics;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_automaticThreshold.CLIJ_automaticThreshold;
+import net.imglib2.img.Img;
 import org.openjdk.jmh.annotations.Benchmark;
-
-import java.awt.*;
 
 public class AutoThreshold2D extends AbstractBenchmark implements BinaryImageBenchmark {
     @Benchmark
@@ -38,5 +37,22 @@ public class AutoThreshold2D extends AbstractBenchmark implements BinaryImageBen
         IJ.setAutoThreshold(imp2D, "Default dark");
         IJ.run(imp2D, "Convert to Mask", "method=Default background=Dark black");
         return imp2D;
+    }
+
+    @Benchmark
+    public Object ijOps(ImgLib2Images images) {
+        Img img2Da = images.getImg2Da();
+        Img img2Dbinarya = images.getImg2Dbinarya();
+        images.getOpService().threshold().otsu(img2Dbinarya, img2Da);
+        return img2Dbinarya;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images) {
+        ClearCLBuffer clb2Da = images.getCLImage2Da();
+        ClearCLBuffer clb2Dc = images.getCLImage2Dc();
+
+        images.getOpService().run(CLIJ_automaticThreshold.class, clb2Dc, clb2Da, "Default");
+        return clb2Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/AutoThreshold3D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/AutoThreshold3D.java
@@ -2,10 +2,9 @@ package net.haesleinhuepf.clij.benchmark.jmh;
 
 import ij.IJ;
 import ij.ImagePlus;
-import ij.plugin.Thresholder;
-import ij.process.AutoThresholder;
-import ij.process.ByteProcessor;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_automaticThreshold.CLIJ_automaticThreshold;
+import net.imglib2.img.Img;
 import org.openjdk.jmh.annotations.Benchmark;
 
 public class AutoThreshold3D extends AbstractBenchmark implements BinaryImageBenchmark {
@@ -37,5 +36,22 @@ public class AutoThreshold3D extends AbstractBenchmark implements BinaryImageBen
         IJ.setAutoThreshold(imp3D, "Default dark");
         IJ.run(imp3D, "Convert to Mask", "method=Default background=Dark black");
         return imp3D;
+    }
+
+    @Benchmark
+    public Object ijOps(ImgLib2Images images) {
+        Img img3Da = images.getImg3Da();
+        Img img3Dbinarya = images.getImg3Dbinarya();
+        images.getOpService().threshold().otsu(img3Dbinarya, img3Da);
+        return img3Dbinarya;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images) {
+        ClearCLBuffer clb3Da = images.getCLImage3Da();
+        ClearCLBuffer clb3Dc = images.getCLImage3Dc();
+
+        images.getOpService().run(CLIJ_automaticThreshold.class, clb3Dc, clb3Da, "Default");
+        return clb3Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/BinaryAnd2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/BinaryAnd2D.java
@@ -7,6 +7,7 @@ import ij.plugin.Thresholder;
 import ij.process.AutoThresholder;
 import ij.process.ByteProcessor;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_binaryAnd.CLIJ_binaryAnd;
 import org.openjdk.jmh.annotations.Benchmark;
 
 public class BinaryAnd2D extends AbstractBenchmark implements BinaryImageBenchmark {
@@ -24,6 +25,17 @@ public class BinaryAnd2D extends AbstractBenchmark implements BinaryImageBenchma
         ClearCLBuffer clb2Dc = images.getCLImage2Dc();
 
         images.clij.op().binaryAnd(clb2Da, clb2Db, clb2Dc);
+        return clb2Dc;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images) {
+
+        ClearCLBuffer clb2Da = images.getCLImage2DBinarya();
+        ClearCLBuffer clb2Db = images.getCLImage2DBinaryb();
+        ClearCLBuffer clb2Dc = images.getCLImage2Dc();
+
+        images.getOpService().run(CLIJ_binaryAnd.class, clb2Dc, clb2Da, clb2Db);
         return clb2Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/BinaryAnd3D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/BinaryAnd3D.java
@@ -2,6 +2,7 @@ package net.haesleinhuepf.clij.benchmark.jmh;
 
 import ij.plugin.ImageCalculator;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_binaryAnd.CLIJ_binaryAnd;
 import org.openjdk.jmh.annotations.Benchmark;
 
 public class BinaryAnd3D extends AbstractBenchmark implements BinaryImageBenchmark {
@@ -18,6 +19,17 @@ public class BinaryAnd3D extends AbstractBenchmark implements BinaryImageBenchma
         ClearCLBuffer clb3Dc = images.getCLImage3Dc();
 
         images.clij.op().binaryAnd(clb3Da, clb3Db, clb3Dc);
+        return clb3Dc;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images) {
+
+        ClearCLBuffer clb3Da = images.getCLImage3DBinarya();
+        ClearCLBuffer clb3Db = images.getCLImage3DBinaryb();
+        ClearCLBuffer clb3Dc = images.getCLImage3Dc();
+
+        images.getOpService().run(CLIJ_binaryAnd.class, clb3Dc, clb3Da, clb3Db);
         return clb3Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Erode2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Erode2D.java
@@ -2,9 +2,12 @@ package net.haesleinhuepf.clij.benchmark.jmh;
 
 import ij.IJ;
 import ij.ImagePlus;
-import ij.gui.WaitForUserDialog;
 import ij.plugin.filter.Binary;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_erodeBox.CLIJ_erodeBox;
+import net.imglib2.algorithm.neighborhood.CenteredRectangleShape;
+import net.imglib2.algorithm.neighborhood.HyperSphereShape;
+import net.imglib2.img.Img;
 import org.openjdk.jmh.annotations.Benchmark;
 
 public class Erode2D extends AbstractBenchmark implements BinaryImageBenchmark {
@@ -38,5 +41,29 @@ public class Erode2D extends AbstractBenchmark implements BinaryImageBenchmark {
         ImagePlus imp2D = images.getImp2DBinarya();
         IJ.run(imp2D, "Erode", "");
         return imp2D;
+    }
+
+    @Benchmark
+    public Object ijOps_sphere(ImgLib2Images images) {
+        Img img2Dbinarya = images.getImg2Dbinarya();
+        Img img2Dbinaryb = images.getImg2Dbinaryb();
+        images.getOpService().morphology().erode(img2Dbinaryb, img2Dbinarya, new HyperSphereShape(1));
+        return img2Dbinaryb;
+    }
+
+    @Benchmark
+    public Object ijOps_box(ImgLib2Images images) {
+        Img img2Dbinarya = images.getImg2Dbinarya();
+        Img img2Dbinaryb = images.getImg2Dbinaryb();
+        images.getOpService().morphology().erode(img2Dbinaryb, img2Dbinarya, new CenteredRectangleShape(new int[]{1,1}, false));
+        return img2Dbinaryb;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ_box(IJ2CLImages images) {
+        ClearCLBuffer clb2Da = images.getCLImage2DBinarya();
+        ClearCLBuffer clb2Dc = images.getCLImage2Dc();
+        images.getOpService().run(CLIJ_erodeBox.class, clb2Dc, clb2Da);
+        return clb2Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Erode3D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Erode3D.java
@@ -1,9 +1,11 @@
 package net.haesleinhuepf.clij.benchmark.jmh;
 
-import ij.IJ;
 import ij.ImagePlus;
-import ij.plugin.filter.Binary;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_erodeBox.CLIJ_erodeBox;
+import net.imglib2.algorithm.neighborhood.CenteredRectangleShape;
+import net.imglib2.algorithm.neighborhood.HyperSphereShape;
+import net.imglib2.img.Img;
 import org.openjdk.jmh.annotations.Benchmark;
 import process3d.Erode_;
 
@@ -29,4 +31,29 @@ public class Erode3D extends AbstractBenchmark implements BinaryImageBenchmark {
         images.clij.op().erodeSphere(clb3Da, clb3Dc);
         return clb3Dc;
     }
+
+    @Benchmark
+    public Object ijOps_sphere(ImgLib2Images images) {
+        Img img3Dbinarya = images.getImg3Dbinarya();
+        Img img3Dbinaryb = images.getImg3Dbinaryb();
+        images.getOpService().morphology().erode(img3Dbinaryb, img3Dbinarya, new HyperSphereShape(1));
+        return img3Dbinaryb;
+    }
+
+    @Benchmark
+    public Object ijOps_box(ImgLib2Images images) {
+        Img img3Dbinarya = images.getImg3Dbinarya();
+        Img img3Dbinaryb = images.getImg3Dbinaryb();
+        images.getOpService().morphology().erode(img3Dbinaryb, img3Dbinarya, new CenteredRectangleShape(new int[]{1,1,1}, false));
+        return img3Dbinaryb;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ_box(IJ2CLImages images) {
+        ClearCLBuffer clb3Da = images.getCLImage3DBinarya();
+        ClearCLBuffer clb3Dc = images.getCLImage3Dc();
+        images.getOpService().run(CLIJ_erodeBox.class, clb3Dc, clb3Da);
+        return clb3Dc;
+    }
+
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Flip2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Flip2D.java
@@ -5,6 +5,7 @@ import ij.ImagePlus;
 import ij.plugin.filter.Binary;
 import ij.plugin.filter.Transformer;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_flip.CLIJ_flip;
 import org.openjdk.jmh.annotations.Benchmark;
 
 public class Flip2D extends AbstractBenchmark {
@@ -30,5 +31,13 @@ public class Flip2D extends AbstractBenchmark {
         ImagePlus imp2D = images.getImp2Da();
         IJ.run(imp2D, "Flip Horizontally", "");
         return imp2D;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images) {
+        ClearCLBuffer clb2Da = images.getCLImage2Da();
+        ClearCLBuffer clb2Dc = images.getCLImage2Dc();
+        images.getOpService().run(CLIJ_flip.class, clb2Dc, clb2Da, true, false, false);
+        return clb2Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Flip3D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Flip3D.java
@@ -2,8 +2,9 @@ package net.haesleinhuepf.clij.benchmark.jmh;
 
 import ij.IJ;
 import ij.ImagePlus;
-import ij.plugin.filter.Transformer;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_flip.CLIJ_flip;
+import net.imglib2.img.Img;
 import org.openjdk.jmh.annotations.Benchmark;
 
 public class Flip3D extends AbstractBenchmark {
@@ -32,5 +33,13 @@ public class Flip3D extends AbstractBenchmark {
         ImagePlus imp3D = images.getImp3Da();
         IJ.run(imp3D, "Flip Horizontally", "stack");
         return imp3D;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images) {
+        ClearCLBuffer clb3Da = images.getCLImage3Da();
+        ClearCLBuffer clb3Dc = images.getCLImage3Dc();
+        images.getOpService().run(CLIJ_flip.class, clb3Dc, clb3Da, true, false, false);
+        return clb3Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/GaussianBlur2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/GaussianBlur2D.java
@@ -47,7 +47,7 @@ public class GaussianBlur2D extends AbstractBenchmark {
         Object img2Da = images.getCLImage3Da();
         Object img2Dc = images.getCLImage3Dc();
         Float sigma = radius.getRadiusF();
-        images.getOpService().run(CLIJ_blur.class, img2Dc, img2Da, sigma, sigma, sigma);
+        images.getOpService().run(CLIJ_blur.class, img2Dc, img2Da, sigma, sigma, 0);
         return img2Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/GaussianBlur2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/GaussianBlur2D.java
@@ -2,9 +2,10 @@ package net.haesleinhuepf.clij.benchmark.jmh;
 
 import ij.IJ;
 import ij.ImagePlus;
-import ij.plugin.filter.Binary;
 import ij.plugin.filter.GaussianBlur;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_blur.CLIJ_blur;
+import net.imglib2.img.Img;
 import org.openjdk.jmh.annotations.Benchmark;
 
 public class GaussianBlur2D extends AbstractBenchmark {
@@ -30,5 +31,23 @@ public class GaussianBlur2D extends AbstractBenchmark {
         ImagePlus imp2D = images.getImp2Da();
         IJ.run(imp2D, "Gaussian Blur...", "sigma=" + radius.getRadiusF());
         return imp2D;
+    }
+
+    @Benchmark
+    public Object ijOps(ImgLib2Images images, Radius radius) {
+        Img img2Da = images.getImg2Da();
+        Img img2Dc = images.getImg2Dc();
+        Float sigma = radius.getRadiusF();
+        images.getOpService().filter().gauss(img2Dc, img2Da, sigma);
+        return img2Dc;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images, Radius radius) {
+        Object img2Da = images.getCLImage3Da();
+        Object img2Dc = images.getCLImage3Dc();
+        Float sigma = radius.getRadiusF();
+        images.getOpService().run(CLIJ_blur.class, img2Dc, img2Da, sigma, sigma, sigma);
+        return img2Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/GaussianBlur3D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/GaussianBlur3D.java
@@ -2,8 +2,9 @@ package net.haesleinhuepf.clij.benchmark.jmh;
 
 import ij.IJ;
 import ij.ImagePlus;
-import ij.plugin.filter.GaussianBlur;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_blur.CLIJ_blur;
+import net.imglib2.img.Img;
 import org.openjdk.jmh.annotations.Benchmark;
 
 public class GaussianBlur3D extends AbstractBenchmark {
@@ -30,5 +31,23 @@ public class GaussianBlur3D extends AbstractBenchmark {
         Float sigma = radius.getRadiusF();
         IJ.run(imp3D, "Gaussian Blur 3D...", "x=" + sigma + " y=" + sigma + " z=" + sigma);
         return imp3D;
+    }
+
+    @Benchmark
+    public Object ijOps(ImgLib2Images images, Radius radius) {
+        Img img3Da = images.getImg3Da();
+        Img img3Dc = images.getImg3Dc();
+        Float sigma = radius.getRadiusF();
+        images.getOpService().filter().gauss(img3Dc, img3Da, sigma);
+        return img3Dc;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images, Radius radius) {
+        Object img3Da = images.getCLImage3Da();
+        Object img3Dc = images.getCLImage3Dc();
+        Float sigma = radius.getRadiusF();
+        images.getOpService().run(CLIJ_blur.class, img3Dc, img3Da, sigma, sigma, sigma);
+        return img3Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/MaximumZProjection.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/MaximumZProjection.java
@@ -3,8 +3,14 @@ package net.haesleinhuepf.clij.benchmark.jmh;
 import ij.IJ;
 import ij.ImagePlus;
 import ij.plugin.ZProjector;
-import ij.plugin.filter.GaussianBlur;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_maxProjection.CLIJ_maximumZProjection;
+import net.imagej.ops.Ops;
+import net.imagej.ops.special.computer.Computers;
+import net.imagej.ops.special.computer.UnaryComputerOp;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.view.Views;
 import org.openjdk.jmh.annotations.Benchmark;
 
 public class MaximumZProjection extends AbstractBenchmark {
@@ -12,6 +18,7 @@ public class MaximumZProjection extends AbstractBenchmark {
     public Object ij(Images images) {
         ImagePlus imp3D = images.getImp2Da();
         ImagePlus imp2D = ZProjector.run(imp3D, "Max Intensity");
+//        System.out.println(Arrays.toString(imp2D.getPixel(0,0)));
         return imp2D;
     }
 
@@ -20,6 +27,7 @@ public class MaximumZProjection extends AbstractBenchmark {
         ClearCLBuffer clb3Da = images.getCLImage3Da();
         ClearCLBuffer clb2Dc = images.getCLImage2Dc();
         images.clij.op().maximumZProjection(clb3Da, clb2Dc);
+//        System.out.println(Arrays.toString(images.clij.pull(clb2Dc).getPixel(0,0)));
         return clb2Dc;
     }
 
@@ -29,4 +37,23 @@ public class MaximumZProjection extends AbstractBenchmark {
         IJ.run(imp3D, "Z Project...", "projection=[Max Intensity]");
         return null;
     }
+
+    @Benchmark
+    public <T> Object ijOps(ImgLib2Images images) {
+        RandomAccessibleInterval<T> img3Da = images.getImg3Da();
+        IterableInterval<T> img2Dc = Views.iterable(images.getImg2Dc());
+        UnaryComputerOp<Iterable<T>, T> maxOp = Computers.unary(images.opService, Ops.Stats.Max.class, (T) null, img2Dc);
+        images.getOpService().transform().project(img2Dc, img3Da, maxOp, 2);
+//        System.out.println(img2Dc.firstElement());
+        return img2Dc;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images) {
+        Object img3Da = images.getCLImage3Da();
+        Object img2Dc = images.getCLImage2Dc();
+        images.getOpService().run(CLIJ_maximumZProjection.class, img2Dc, img3Da);
+        return img2Dc;
+    }
+
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Mean2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Mean2D.java
@@ -2,16 +2,19 @@ package net.haesleinhuepf.clij.benchmark.jmh;
 
 import ij.IJ;
 import ij.ImagePlus;
-import ij.ImageStack;
 import ij.plugin.filter.RankFilters;
 import ij.process.ByteProcessor;
 import ij.process.ColorProcessor;
 import ij.process.FloatProcessor;
 import ij.process.ShortProcessor;
-import mcib3d.image3d.processing.FastFilters3D;
 import mpicbg.ij.integral.Mean;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_meanBox.CLIJ_meanBox;
+import net.haesleinhuepf.clij.ops.CLIJ_meanSphere.CLIJ_meanSphere;
 import net.haesleinhuepf.clij.utilities.CLIJUtilities;
+import net.imglib2.algorithm.neighborhood.CenteredRectangleShape;
+import net.imglib2.algorithm.neighborhood.HyperSphereShape;
+import net.imglib2.img.Img;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
@@ -76,4 +79,39 @@ public class Mean2D extends AbstractBenchmark {
         return imp2D;
     }
 
+    @Benchmark
+    public Object ijOps_box(ImgLib2Images images, Radius radius) {
+        Img img2Da = images.getImg2Da();
+        Img img2Dc = images.getImg2Dc();
+        int rad = (int)radius.getRadiusF();
+        images.getOpService().filter().mean(img2Dc, img2Da, new CenteredRectangleShape(new int[]{rad, rad}, false));
+        return img2Dc;
+    }
+
+    @Benchmark
+    public Object ijOps_sphere(ImgLib2Images images, Radius radius) {
+        Img img2Da = images.getImg2Da();
+        Img img2Dc = images.getImg2Dc();
+        int rad = (int)radius.getRadiusF();
+        images.getOpService().filter().mean(img2Dc, img2Da, new HyperSphereShape(rad));
+        return img2Dc;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ_box(IJ2CLImages images, Radius radius) {
+        Object img2Da = images.getCLImage2Da();
+        Object img2Dc = images.getCLImage2Dc();
+        int rad = (int)radius.getRadiusF();
+        images.getOpService().run(CLIJ_meanBox.class, img2Dc, img2Da, rad, rad);
+        return img2Dc;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ_sphere(IJ2CLImages images, Radius radius) {
+        Object img2Da = images.getCLImage2Da();
+        Object img2Dc = images.getCLImage2Dc();
+        int rad = (int)radius.getRadiusF();
+        images.getOpService().run(CLIJ_meanSphere.class, img2Dc, img2Da, rad, rad);
+        return img2Dc;
+    }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Median2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Median2D.java
@@ -3,17 +3,15 @@ package net.haesleinhuepf.clij.benchmark.jmh;
 import ij.IJ;
 import ij.ImagePlus;
 import ij.plugin.filter.RankFilters;
-import ij.process.ByteProcessor;
-import ij.process.ColorProcessor;
-import ij.process.FloatProcessor;
-import ij.process.ShortProcessor;
-import mpicbg.ij.integral.Mean;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_medianSphere.CLIJ_medianSphere;
 import net.haesleinhuepf.clij.utilities.CLIJUtilities;
+import net.imglib2.algorithm.neighborhood.CenteredRectangleShape;
+import net.imglib2.algorithm.neighborhood.HyperSphereShape;
+import net.imglib2.img.Img;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
-import process3d.Median_;
 
 @State(Scope.Benchmark)
 public class Median2D extends AbstractBenchmark {
@@ -54,5 +52,32 @@ public class Median2D extends AbstractBenchmark {
         rankFilters.setup("median", imp);
         rankFilters.rank(imp.getProcessor(), radius.getRadiusF(), RankFilters.MEDIAN);
         return imp;
+    }
+
+    @Benchmark
+    public Object ijOps_box(ImgLib2Images images, Radius radius) {
+        Img img2Da = images.getImg2Da();
+        Img img2Dc = images.getImg2Dc();
+        int rad = (int)radius.getRadiusF();
+        images.getOpService().filter().median(img2Dc, img2Da, new CenteredRectangleShape(new int[]{rad, rad}, false));
+        return img2Dc;
+    }
+
+    @Benchmark
+    public Object ijOps_sphere(ImgLib2Images images, Radius radius) {
+        Img img2Da = images.getImg2Da();
+        Img img2Dc = images.getImg2Dc();
+        int rad = (int)radius.getRadiusF();
+        images.getOpService().filter().median(img2Dc, img2Da, new HyperSphereShape(rad));
+        return img2Dc;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ_sphere(IJ2CLImages images, Radius radius) {
+        Object img2Da = images.getCLImage2Da();
+        Object img2Dc = images.getCLImage2Dc();
+        int rad = (int)radius.getRadiusF();
+        images.getOpService().run(CLIJ_medianSphere.class, img2Dc, img2Da, rad, rad);
+        return img2Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Median3D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Median3D.java
@@ -6,7 +6,11 @@ import ij.ImageStack;
 import ij.plugin.Filters3D;
 import mcib3d.image3d.processing.FastFilters3D;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_medianSphere.CLIJ_medianSphere;
 import net.haesleinhuepf.clij.utilities.CLIJUtilities;
+import net.imglib2.algorithm.neighborhood.CenteredRectangleShape;
+import net.imglib2.algorithm.neighborhood.HyperSphereShape;
+import net.imglib2.img.Img;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
@@ -66,5 +70,32 @@ public class Median3D extends AbstractBenchmark {
         int rad = (int)radius.getRadiusF();
         ImageStack res = FastFilters3D.filterImageStack(imp.getImageStack(), FastFilters3D.MEDIAN, rad, rad, rad, 0, false);
         return new ImagePlus("filtered", res);
+    }
+
+    @Benchmark
+    public Object ijOps_box(ImgLib2Images images, Radius radius) {
+        Img img3Da = images.getImg3Da();
+        Img img3Dc = images.getImg3Dc();
+        int rad = (int)radius.getRadiusF();
+        images.getOpService().filter().median(img3Dc, img3Da, new CenteredRectangleShape(new int[]{rad, rad, rad}, false));
+        return img3Dc;
+    }
+
+    @Benchmark
+    public Object ijOps_sphere(ImgLib2Images images, Radius radius) {
+        Img img3Da = images.getImg3Da();
+        Img img3Dc = images.getImg3Dc();
+        int rad = (int)radius.getRadiusF();
+        images.getOpService().filter().median(img3Dc, img3Da, new HyperSphereShape(rad));
+        return img3Dc;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ_sphere(IJ2CLImages images, Radius radius) {
+        Object img3Da = images.getCLImage3Da();
+        Object img3Dc = images.getCLImage3Dc();
+        int rad = (int)radius.getRadiusF();
+        images.getOpService().run(CLIJ_medianSphere.class, img3Dc, img3Da, rad, rad, rad);
+        return img3Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Minimum2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Minimum2D.java
@@ -66,7 +66,7 @@ public class Minimum2D extends AbstractBenchmark {
         Object img2Da = images.getCLImage2Da();
         Object img2Dc = images.getCLImage2Dc();
         int rad = (int)radius.getRadiusF();
-        images.getOpService().run(CLIJ_minimumBox.class, img2Dc, img2Da, rad, rad, rad);
+        images.getOpService().run(CLIJ_minimumBox.class, img2Dc, img2Da, rad, rad, 0);
         return img2Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Minimum2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Minimum2D.java
@@ -4,7 +4,11 @@ import ij.IJ;
 import ij.ImagePlus;
 import ij.plugin.filter.RankFilters;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_minimumBox.CLIJ_minimumBox;
 import net.haesleinhuepf.clij.utilities.CLIJUtilities;
+import net.imglib2.algorithm.neighborhood.CenteredRectangleShape;
+import net.imglib2.algorithm.neighborhood.HyperSphereShape;
+import net.imglib2.img.Img;
 import org.openjdk.jmh.annotations.*;
 
 @State(Scope.Benchmark)
@@ -39,4 +43,30 @@ public class Minimum2D extends AbstractBenchmark {
         return imp;
     }
 
+    @Benchmark
+    public Object ijOps_sphere(ImgLib2Images images, Radius radius) {
+        Img img2Da = images.getImg2Da();
+        Img img2Dc = images.getImg2Dc();
+        int rad = (int)radius.getRadiusF();
+        images.getOpService().filter().min(img2Dc, img2Da, new HyperSphereShape(rad));
+        return img2Dc;
+    }
+
+    @Benchmark
+    public Object ijOps_box(ImgLib2Images images, Radius radius) {
+        Img img2Da = images.getImg2Da();
+        Img img2Dc = images.getImg2Dc();
+        int rad = (int)radius.getRadiusF();
+        images.getOpService().filter().min(img2Dc, img2Da, new CenteredRectangleShape(new int[]{rad, rad}, false));
+        return img2Dc;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ_box(IJ2CLImages images, Radius radius) {
+        Object img2Da = images.getCLImage2Da();
+        Object img2Dc = images.getCLImage2Dc();
+        int rad = (int)radius.getRadiusF();
+        images.getOpService().run(CLIJ_minimumBox.class, img2Dc, img2Da, rad, rad, rad);
+        return img2Dc;
+    }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Minimum3D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Minimum3D.java
@@ -6,7 +6,11 @@ import ij.ImageStack;
 import ij.plugin.Filters3D;
 import mcib3d.image3d.processing.FastFilters3D;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_minimumBox.CLIJ_minimumBox;
 import net.haesleinhuepf.clij.utilities.CLIJUtilities;
+import net.imglib2.algorithm.neighborhood.CenteredRectangleShape;
+import net.imglib2.algorithm.neighborhood.HyperSphereShape;
+import net.imglib2.img.Img;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
@@ -44,5 +48,32 @@ public class Minimum3D extends AbstractBenchmark {
         ImagePlus imp = images.getImp3Da();
         ImageStack res = FastFilters3D.filterImageStack(imp.getImageStack(), FastFilters3D.MIN, radius.getRadiusF(), radius.getRadiusF(), radius.getRadiusF(), 0, false);
         return new ImagePlus("filtered", res);
+    }
+
+    @Benchmark
+    public Object ijOps_sphere(ImgLib2Images images, Radius radius) {
+        Img img3Da = images.getImg3Da();
+        Img img3Dc = images.getImg3Dc();
+        int rad = (int)radius.getRadiusF();
+        images.getOpService().filter().min(img3Dc, img3Da, new HyperSphereShape(rad));
+        return img3Dc;
+    }
+
+    @Benchmark
+    public Object ijOps_box(ImgLib2Images images, Radius radius) {
+        Img img3Da = images.getImg3Da();
+        Img img3Dc = images.getImg3Dc();
+        int rad = (int)radius.getRadiusF();
+        images.getOpService().filter().min(img3Dc, img3Da, new CenteredRectangleShape(new int[]{rad, rad, rad}, false));
+        return img3Dc;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ_box(IJ2CLImages images, Radius radius) {
+        Object img3Da = images.getCLImage3Da();
+        Object img3Dc = images.getCLImage3Dc();
+        int rad = (int)radius.getRadiusF();
+        images.getOpService().run(CLIJ_minimumBox.class, img3Dc, img3Da, rad, rad, rad);
+        return img3Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/MultiplyScalar2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/MultiplyScalar2D.java
@@ -3,6 +3,11 @@ package net.haesleinhuepf.clij.benchmark.jmh;
 import ij.IJ;
 import ij.ImagePlus;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_flip.CLIJ_flip;
+import net.haesleinhuepf.clij.ops.CLIJ_multiplyImageAndScalar.CLIJ_multiplyImageAndScalar;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.Views;
 import org.openjdk.jmh.annotations.Benchmark;
 
 public class MultiplyScalar2D extends AbstractBenchmark {
@@ -26,5 +31,23 @@ public class MultiplyScalar2D extends AbstractBenchmark {
         ImagePlus imp2D = images.getImp2Da();
         IJ.run(imp2D, "Multiply...", "value=2");
         return imp2D;
+    }
+
+    @Benchmark
+    public <T extends RealType> Object ijOps(ImgLib2Images images) {
+        Img img2Da = images.getImg2Da();
+        Img img2Dc = images.getImg2Dc();
+        T val = ((Img<T>) img2Da).firstElement();
+        val.setReal(2);
+        images.getOpService().math().multiply(Views.iterable(img2Dc), img2Da, val);
+        return img2Dc;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images) {
+        ClearCLBuffer clb2Da = images.getCLImage2Da();
+        ClearCLBuffer clb2Dc = images.getCLImage2Dc();
+        images.getOpService().run(CLIJ_multiplyImageAndScalar.class, clb2Dc, clb2Da, 2f);
+        return clb2Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/MultiplyScalar2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/MultiplyScalar2D.java
@@ -37,7 +37,7 @@ public class MultiplyScalar2D extends AbstractBenchmark {
     public <T extends RealType> Object ijOps(ImgLib2Images images) {
         Img img2Da = images.getImg2Da();
         Img img2Dc = images.getImg2Dc();
-        T val = ((Img<T>) img2Da).firstElement();
+        T val = (T) ((Img<T>) img2Da).firstElement().copy();
         val.setReal(2);
         images.getOpService().math().multiply(Views.iterable(img2Dc), img2Da, val);
         return img2Dc;

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/MultiplyScalar3D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/MultiplyScalar3D.java
@@ -3,6 +3,10 @@ package net.haesleinhuepf.clij.benchmark.jmh;
 import ij.IJ;
 import ij.ImagePlus;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_multiplyImageAndScalar.CLIJ_multiplyImageAndScalar;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.Views;
 import org.openjdk.jmh.annotations.Benchmark;
 
 public class MultiplyScalar3D extends AbstractBenchmark {
@@ -30,5 +34,23 @@ public class MultiplyScalar3D extends AbstractBenchmark {
         ImagePlus imp3D = images.getImp3Da();
         IJ.run(imp3D, "Multiply...", "value=2 stack");
         return imp3D;
+    }
+
+    @Benchmark
+    public <T extends RealType> Object ijOps(ImgLib2Images images) {
+        Img img3Da = images.getImg2Da();
+        Img img3Dc = images.getImg2Dc();
+        T val = ((Img<T>) img3Da).firstElement();
+        val.setReal(2);
+        images.getOpService().math().multiply(Views.iterable(img3Dc), img3Da, val);
+        return img3Dc;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images) {
+        ClearCLBuffer clb3Da = images.getCLImage3Da();
+        ClearCLBuffer clb3Dc = images.getCLImage3Dc();
+        images.getOpService().run(CLIJ_multiplyImageAndScalar.class, clb3Dc, clb3Da, 2f);
+        return clb3Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/MultiplyScalar3D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/MultiplyScalar3D.java
@@ -38,9 +38,9 @@ public class MultiplyScalar3D extends AbstractBenchmark {
 
     @Benchmark
     public <T extends RealType> Object ijOps(ImgLib2Images images) {
-        Img img3Da = images.getImg2Da();
-        Img img3Dc = images.getImg2Dc();
-        T val = ((Img<T>) img3Da).firstElement();
+        Img img3Da = images.getImg3Da();
+        Img img3Dc = images.getImg3Dc();
+        T val = (T) ((Img<T>) img3Da).firstElement().copy();
         val.setReal(2);
         images.getOpService().math().multiply(Views.iterable(img3Dc), img3Da, val);
         return img3Dc;

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/RadialReslice.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/RadialReslice.java
@@ -13,6 +13,7 @@ import ij.plugin.filter.PlugInFilter;
 import ij.process.ColorProcessor;
 import ij.process.ImageProcessor;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_radialProjection.CLIJ_radialProjection;
 import org.openjdk.jmh.annotations.Benchmark;
 
 import java.awt.*;
@@ -299,6 +300,19 @@ public class RadialReslice extends AbstractBenchmark {
         }
 
 
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images) {
+        ClearCLBuffer clb3Da = images.getCLImage3Da();
+
+        int numberOfAngles = 360;
+        float angleStepSize = 1.0f;
+        ClearCLBuffer clb3Dc = (ClearCLBuffer) images.getOpService().run(CLIJ_radialProjection.class, clb3Da, numberOfAngles, angleStepSize);
+
+        clb3Dc.close();
+
+        return null;
     }
 
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Rotate2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Rotate2D.java
@@ -10,6 +10,7 @@ import ij.process.FloatProcessor;
 import ij.process.ShortProcessor;
 import mpicbg.ij.integral.Mean;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_rotateLeft.CLIJ_rotateLeft;
 import net.haesleinhuepf.clij.utilities.CLIJUtilities;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
@@ -44,4 +45,13 @@ public class Rotate2D extends AbstractBenchmark {
         return imp2D;
     }
 
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images) {
+        ClearCLBuffer clb2Da = images.getCLImage2Da();
+        ClearCLBuffer clb2Dc = images.getCLImage2Dc();
+
+        images.getOpService().run(CLIJ_rotateLeft.class, clb2Dc, clb2Da);
+
+        return clb2Dc;
+    }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Rotate3D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Rotate3D.java
@@ -4,6 +4,10 @@ import ij.IJ;
 import ij.ImagePlus;
 import ij.plugin.filter.Transformer;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_minimumBox.CLIJ_minimumBox;
+import net.haesleinhuepf.clij.ops.CLIJ_rotateLeft.CLIJ_rotateLeft;
+import net.imglib2.algorithm.neighborhood.CenteredRectangleShape;
+import net.imglib2.img.Img;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
@@ -28,4 +32,13 @@ public class Rotate3D extends AbstractBenchmark {
         return clb3Dc;
     }
 
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images) {
+        ClearCLBuffer clb3Da = images.getCLImage3Da();
+        ClearCLBuffer clb3Dc = images.getCLImage3Dc();
+
+        images.getOpService().run(CLIJ_rotateLeft.class, clb3Dc, clb3Da);
+
+        return clb3Dc;
+    }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Threshold2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Threshold2D.java
@@ -41,7 +41,7 @@ public class Threshold2D extends AbstractBenchmark implements BinaryImageBenchma
     public <T extends RealType> Object ijOps(ImgLib2Images images) {
         Img img2Da = images.getImg2Da();
         Img img2Dbinarya = images.getImg2Dbinarya();
-        T val = ((Img<T>) img2Da).firstElement();
+        T val = (T) ((Img<T>) img2Da).firstElement().copy();
         val.setReal(128);
         images.getOpService().threshold().apply(img2Dbinarya, img2Da, val);
         return img2Dbinarya;

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Threshold2D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Threshold2D.java
@@ -3,9 +3,12 @@ package net.haesleinhuepf.clij.benchmark.jmh;
 import ij.IJ;
 import ij.ImagePlus;
 import ij.plugin.Thresholder;
-import ij.process.AutoThresholder;
 import ij.process.ByteProcessor;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_automaticThreshold.CLIJ_automaticThreshold;
+import net.haesleinhuepf.clij.ops.CLIJ_threshold.CLIJ_threshold;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
 import org.openjdk.jmh.annotations.Benchmark;
 
 public class Threshold2D extends AbstractBenchmark implements BinaryImageBenchmark {
@@ -32,5 +35,23 @@ public class Threshold2D extends AbstractBenchmark implements BinaryImageBenchma
         IJ.setThreshold(imp2D, 128, 255);
         IJ.run(imp2D, "Convert to Mask", "method=Default background=Dark black");
         return imp2D;
+    }
+
+    @Benchmark
+    public <T extends RealType> Object ijOps(ImgLib2Images images) {
+        Img img2Da = images.getImg2Da();
+        Img img2Dbinarya = images.getImg2Dbinarya();
+        T val = ((Img<T>) img2Da).firstElement();
+        val.setReal(128);
+        images.getOpService().threshold().apply(img2Dbinarya, img2Da, val);
+        return img2Dbinarya;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images) {
+        ClearCLBuffer clb2Da = images.getCLImage2Da();
+        ClearCLBuffer clb2Dc = images.getCLImage2Dc();
+        images.getOpService().run(CLIJ_threshold.class, clb2Dc, clb2Da, 128f);
+        return clb2Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Threshold3D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Threshold3D.java
@@ -6,6 +6,9 @@ import ij.plugin.Thresholder;
 import ij.process.AutoThresholder;
 import ij.process.ByteProcessor;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
+import net.haesleinhuepf.clij.ops.CLIJ_threshold.CLIJ_threshold;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.RealType;
 import org.openjdk.jmh.annotations.Benchmark;
 
 public class Threshold3D extends AbstractBenchmark implements BinaryImageBenchmark {
@@ -25,5 +28,23 @@ public class Threshold3D extends AbstractBenchmark implements BinaryImageBenchma
         IJ.setThreshold(imp3D, 128, 255);
         IJ.run(imp3D, "Convert to Mask", "method=Default background=Dark black");
         return imp3D;
+    }
+
+    @Benchmark
+    public <T extends RealType> Object ijOps(ImgLib2Images images) {
+        Img img3Da = images.getImg3Da();
+        Img img3Dbinarya = images.getImg3Dbinarya();
+        T val = ((Img<T>) img3Da).firstElement();
+        val.setReal(128);
+        images.getOpService().threshold().apply(img3Dbinarya, img3Da, val);
+        return img3Dbinarya;
+    }
+
+    @Benchmark
+    public Object ijOpsCLIJ(IJ2CLImages images) {
+        ClearCLBuffer clb3Da = images.getCLImage3Da();
+        ClearCLBuffer clb3Dc = images.getCLImage3Dc();
+        images.getOpService().run(CLIJ_threshold.class, clb3Dc, clb3Da, 128f);
+        return clb3Dc;
     }
 }

--- a/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Threshold3D.java
+++ b/src/main/java/net/haesleinhuepf/clij/benchmark/jmh/Threshold3D.java
@@ -34,7 +34,7 @@ public class Threshold3D extends AbstractBenchmark implements BinaryImageBenchma
     public <T extends RealType> Object ijOps(ImgLib2Images images) {
         Img img3Da = images.getImg3Da();
         Img img3Dbinarya = images.getImg3Dbinarya();
-        T val = ((Img<T>) img3Da).firstElement();
+        T val = (T) ((Img<T>) img3Da).firstElement().copy();
         val.setReal(128);
         images.getOpService().threshold().apply(img3Dbinarya, img3Da, val);
         return img3Dbinarya;


### PR DESCRIPTION
`AbstractBenchmark` / `ImageComparison`:
* adds `AbstractBenchmark.ImgLib2Images` for ImgLib2 Ops
* adds `AbstractBenchmark.IJ2CLImages` for CLIJ Ops
* changing the `AbstractBenchmark.Images` class a bit to make the other Images implementations work with `ImageComparison`

Benchmark methods:
* adding benchmark methods for ImgLib2 Ops
* adding benchmark methods for CLIJ Ops
* the `ijOpsCLIJ` methods should be the same as the `clij` methods with the additional Ops matching overhead, but having them as well makes it easier to compare CLIJ with ImgLib2 in the IJ2 Ops world